### PR TITLE
fix parse bug for multiple file contracts

### DIFF
--- a/src/legacyCompiler.ts
+++ b/src/legacyCompiler.ts
@@ -1,3 +1,4 @@
+
 import os from "os";
 import { ChildProcess, spawnSync, exec, execSync } from 'child_process';
 import {Contract} from "./contract"
@@ -28,8 +29,6 @@ function parse(output: string, source: string) {
     let line = lines[i];
     if (line.startsWith("======= ")) {
       let _source = line.slice("======= ".length, -" =======".length).split(":")[0].trim();
-      if (_source !== source)
-        continue;
       contractName = line.slice("======= ".length, -" =======".length).split(":")[1].trim();
       compiledContracts[contractName] = new Contract(contractName, '', {});
     } else if (line.startsWith("Binary:")) {


### PR DESCRIPTION
When multiple contracts are compiled, the legacy compiler may overwrite the target contract properties with data from other contracts since `contractName` is only set once during the parsing loop.

Since `parse` is already designed to return multiple contracts as an object, it may as well save the data for each compiled contract (an alternate solution would be to add a `contractName=""` in the if block).